### PR TITLE
Fix Op mapping; add node/iter APIs

### DIFF
--- a/docs/PROPOSALS.md
+++ b/docs/PROPOSALS.md
@@ -29,8 +29,8 @@ Add README/API docs with examples for:
 - Borrowing buffer/parameter bytes: `get_*_view` and `extract_*_view`
 - Lifetime constraints: the view is tied to the GIL token and should not be stored beyond its scope
 - Read-only semantics: do not mutate the underlying tensor while viewing
-Status: In progress
-- TODO: Update README with examples and safety notes.
+Status: Completed
+- Added README section "Zero-Copy Views: Safety & Usage" documenting GIL-tied lifetime, read-only semantics, strided behavior, and a usage example.
 
 ## 4) Optional typed views
 


### PR DESCRIPTION
Title: Fix Op mapping; add node/iter APIs

Summary
- Fix swapped `call_method`/`call_module` mapping in `Op`.
- Add zero-copy node-ref helpers on `Graph` to avoid name copies.
- Add iterator-based parameter/buffer view APIs on `GraphModule` to avoid `HashMap` allocations.
- Document `BufferView<'py>` safety and usage in README.
- Update `docs/PROPOSALS.md` with completed items.

Why
- Aligns `Op` enum with `torch.fx` semantics to prevent confusion.
- Reduces allocations and copying:
  - Node helpers return `&Node` instead of copying `String` names.
  - Iterator APIs stream `(name, BufferView)` lazily without building maps.
- Clarifies safety of zero-copy views: GIL-bound lifetime, read-only semantics, strided notes.

Changes
- src/fx/mod.rs
  - Fix `FromPyObject` mapping: `call_method` → `Op::CallMethod`, `call_module` → `Op::CallModule`.
  - Add unit tests: mapping correctness + IntoPy roundtrips.
- src/fx/graph.rs
  - Add `flatten_node_args_nodes(&self, node_name) -> PyResult<Option<Vec<&Node>>>`.
  - Add `users_nodes(&self, node_name) -> PyResult<Option<Vec<&Node>>>`.
- src/fx/graph_module.rs
  - Add `iter_parameters_view<'py>(&'py self, py) -> PyResult<impl Iterator<Item = PyResult<(String, BufferView<'py>)>> + 'py>`.
  - Add `iter_buffers_view<'py>(&'py self, py) -> PyResult<impl Iterator<Item = PyResult<(String, BufferView<'py>)>> + 'py>`.
  - Implement lightweight `DictViewIter<'py>` over `&PyDict`.
- tests/fx.rs
  - Add `unittest_users_and_flatten_node_args_nodes`.
  - Add `unittest_iter_views_rust`.
- README.md
  - Add “Zero-Copy Views: Safety & Usage” with example.
  - Document new methods on `Graph` and `GraphModule`.
  - Fix references to `BufferView<'py>`.
- docs/PROPOSALS.md
  - Mark #1 Node-based APIs as Completed.
  - Mark #2 Op mapping as Completed.
  - Mark #3 BufferView docs as Completed.
  - Mark #5 Iterator APIs as Completed.
  - Mark #6 View tests as Completed.

Compatibility
- Additive changes only; no breaking APIs.

Testing
- cargo fmt — clean
- cargo clippy — clean
- cargo test — all pass
  - Unit: 2
  - Integration: 18 (Python 3.10 + torch)

Future Work
- Typed views (#4): consider “with meta” variants (e.g., `get_*_view_with_meta` / `iter_*_view_with_meta`) to pair `BufferView<'py>` with `TensorMeta` while keeping the view type minimal.
